### PR TITLE
Support arbitrary CA chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ var options = {
     key: "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----", // (required unless using 'key_path') contents of private key
     organization: "myorganization", // (required unless using 'url') organization name for use with hosted chef
     url: "https://mychefserver.com:4000", // (required unless using 'organization') url for use with private chef server
+    ca: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----", // if this key is omitted, then the default CA chain will be used. If null, the client will operate unsafely and not validate the server's certificat, it set to a certificate list explicitly, that list will be used as the CA chain.
 }
 
 chef.config(options);

--- a/chef-api.js
+++ b/chef-api.js
@@ -11,6 +11,12 @@ exports.getObject = function(){
         object.options.name =  options.user_name || options.client_name,
         object.options.key_contents = options.key || fs.readFileSync(options.key_path),
         object.options.host_url = options.url || ["https://api.opscode.com/organizations", options.organization].join("/")
+        if(options.hasOwnProperty("ca")) {
+            // absent means default,
+            // null means unsafe,
+            // specific means specific
+            object.options.ca = options.ca;
+        }
     }
 
     _.each(methodsFiles, function(file){

--- a/operations.js
+++ b/operations.js
@@ -65,13 +65,22 @@ exports.operations = function(config){
                 if(qs)
                     data.qs = qs;
 
+                if(config.hasOwnProperty('ca')) {
+                    if(config.ca === null) {
+                        data.strictSSL = false;
+                        data.rejectUnauthorized = false;
+                    }
+                    else
+                        data.ca = config.ca;
+                }
+
                 if(body){
                     data.body = JSON.stringify(body);
                     data.headers['Content-type'] = "application/json";
                 }
 
                 request(data, function(err, response){
-                    fn(err, JSON.parse(response.body));
+                    fn(err, JSON.parse(response ? response.body : null));
                 });
             });
         }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/normanjoyner/chef-api.git"
   },
   "dependencies": {
-    "request": "2.12.x",
+    "request": "2.21.x",
     "underscore": "1.4.x",
     "ursa": "0.8.x"
   },


### PR DESCRIPTION
This patch allows a "ca" key argument in the chef-api options.

Omitting this key preserves existing behaviour.

Setting to null explicitly, turns off validation.

Setting to a string containing the CA chain contents, uses that CA chain.
