### PR TITLE
added postSearchIndex

### DIFF
--- a/methods/search.js
+++ b/methods/search.js
@@ -8,17 +8,19 @@ exports.methods = function(config){
             http_methods.get([config.host_url, "search"].join("/"), null, function(err, response){
                 return fn(err, response);
             });
-        }, 
+        },
 
         // http://docs.opscode.com/api_chef_server_search_index.html#get
         getSearchIndex: function(index, qs, fn){
             http_methods.get([config.host_url, "search", index].join("/"), qs, function(err, response){
                 return fn(err, response);
             });
+        },
+        // http://docs.opscode.com/api_chef_server_search_index.html#post
+        postSearchIndex: function(index, data, fn){
+            http_methods.post([config.host_url, "search", index].join("/"), data, function(err, response){
+                return fn(err, response);
+            });
         }
-        /*
-            not yet implemented:
-            // http://docs.opscode.com/api_chef_server_search_index.html#post
-        */
     }
 }


### PR DESCRIPTION
`postSearchIndex` is not taking `data` argument correctly at the moment, however if you pass and empty object `{}`, search will correctly return all nodes.

``` javascript
chef.postSearchIndex('node', {}, function(err, res) {
   /* ... */ 
});
```
