### PR TITLE
added the editEnvironment method

### DIFF
--- a/methods/environments.js
+++ b/methods/environments.js
@@ -17,6 +17,13 @@ exports.methods = function(config){
             });
         },
 
+        // http://docs.opscode.com/api_chef_server_environments_name.html#put
+        editEnvironment: function(environment, body, fn){
+            http_methods.put([config.host_url, "environments", environment].join("/"),null ,body, function(err, response){
+                return fn(err, response);
+            });
+        },
+
         // http://docs.opscode.com/api_chef_server_environments_name.html#get
         getEnvironment: function(environment, fn){
             http_methods.get([config.host_url, "environments", environment].join("/"), null, function(err, response){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chef-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A simple chef server api wrapper",
   "author": "Norman Joyner <norman.joyner@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Hi.  I'm a big fan of your library, and have been using it to avoid having to deal with knife/ruby ugliness with some of our deployment processes.  I've hit a minor road block as I need to be able to patch an Environment setting from one of my scripts, and the current version of chef-api does not have a method to do so.   This pull request adds the editEnvironment method, using the Chef-Api put method to update the environment.  I've tested the change against our own Chef environment and it works fine.

I would be much obliged if you'd be willing to merge this pull request and update your lib on npm.

Thanks a million,
-H
