### PR TITLE
update_ursa

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -115,8 +115,8 @@
       }
     },
     "ursa": {
-      "version": "0.8.0",
-      "from": "ursa@0.8.0"
+      "version": "0.8.5",
+      "from": "ursa@0.8.5"
     },
     "lodash": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "request": "2.29.0",
-    "ursa": "0.8.0",
+    "ursa": "0.8.5",
     "lodash": "2.2.1"
   },
   "engines": {


### PR DESCRIPTION
Update ursa to 0.8.5 so chef-api will compile and run under node 12.x
Fixes #20
Fixes #21
Probably fixes #15 

Please note i only tested insofar as it now successfully does an NPM install.