### PR TITLE
Migrate from ursa to forsake to fix deployment in Node 6.x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -379,23 +379,6 @@
           }
         }
       }
-    },
-    "ursa": {
-      "version": "0.9.1",
-      "from": "http://registry.npmjs.org/ursa/-/ursa-0.9.1.tgz",
-      "resolved": "http://registry.npmjs.org/ursa/-/ursa-0.9.1.tgz",
-      "dependencies": {
-        "bindings": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-        },
-        "nan": {
-          "version": "2.1.0",
-          "from": "http://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
-        }
-      }
     }
   }
 }

--- a/operations.js
+++ b/operations.js
@@ -4,7 +4,7 @@ var url = require('url');
 var crypto = require('crypto');
 var exec = require('child_process').exec;
 var _ = require("lodash");
-var key = require('ursa').coercePrivateKey;
+var forsake = require('forsake');
 
 exports.operations = function(config){
     return {
@@ -25,8 +25,6 @@ exports.operations = function(config){
                 return header.join(":");
             }).join("\n");
 
-            var signature = key(config.key_contents).privateEncrypt(request_headers, 'utf8', 'base64');
-
             var auth_headers = {
                 "Accept": "application/json",
                 "X-Ops-Timestamp": timestamp,
@@ -36,8 +34,10 @@ exports.operations = function(config){
                 "X-Ops-Sign": "version=1.0"
             };
 
+            var sig = forsake.sign(request_headers, config.key_contents).toString('base64');
+
             var auth_header_count = 0;
-            _.each(signature.match(/.{1,60}/g), function(signature_section){
+            _.each(sig.match(/.{1,60}/g), function(signature_section){
                 var name = ["X-Ops-Authorization", ++auth_header_count].join("-");
                 auth_headers[name] = signature_section;
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chef-api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A simple chef server api wrapper",
   "author": "Norman Joyner <norman.joyner@gmail.com>",
   "license": "GPLv2",
@@ -13,7 +13,7 @@
   "dependencies": {
     "lodash": "^2.2.1",
     "request": "^2.61.0",
-    "ursa": "^0.9.1"
+    "forsake": "^0.1.4"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
The ursa node module no longer compiles against Node.js 6.x and seems to currently lack a maintainer. Forsake is mostly a drop-in replacement. I've tested some simple node/cookbook GET requests against a PEM-authenticated Chef server.